### PR TITLE
Fix table of contents loading

### DIFF
--- a/chapters/chapters.json
+++ b/chapters/chapters.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "chap-1",
+    "index": 1,
+    "title": "Chap 1",
+    "path": "chapters/chap-1"
+  }
+]

--- a/index.html
+++ b/index.html
@@ -486,6 +486,14 @@ async function findExistingUrl(chPath, ch, i){
 }
 async function chapExists(n){ return await findExistingUrl(`chapters/chap-${n}`, n, 1) !== null; }
 async function buildChaptersAuto(){
+  try{
+    const res = await fetch('chapters/chapters.json');
+    if(res.ok){
+      return await res.json();
+    }
+  }catch(err){
+    console.warn('Falling back to probing chapters', err);
+  }
   const chapters=[];
   for(let i=1;i<=999;i++){
     if(!(await chapExists(i))) break;


### PR DESCRIPTION
## Summary
- Load chapter list from `chapters.json` when building TOC, falling back to probing if missing
- Add static `chapters.json` manifest for available chapters

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b69cc64248322a3d8dd66c33e464c