### PR TITLE
Fix auth display and support anonymous name input

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
     .mini-head{display:grid;grid-template-columns:auto 1fr auto auto;align-items:center;gap:8px;padding:10px 12px;border-bottom:1px solid var(--bd)}
     .mini-hint{color:var(--muted);font-size:12px;text-align:center}
     .mini-body{flex:1;overflow:auto;padding:8px;-webkit-overflow-scrolling:touch}
-    .mini-composer{display:flex;gap:8px;align-items:center;margin-top:8px}
+    .mini-composer{display:flex;flex-direction:column;gap:4px;margin-top:8px}
     .mini-composer input{flex:1}
     .cmt-item{border-top:1px dashed #223; padding:8px 6px}
     .cmt-meta{color:#9fb0c0; font-size:12px; margin-bottom:4px}
@@ -148,6 +148,7 @@
           <div style="font-weight:600">Viết bình luận cho trang này</div>
           <button class="btn small" id="panelAuthBtn">Đăng nhập GitHub</button>
         </div>
+        <input id="panelName" placeholder="Tên của bạn..." style="margin-bottom:8px">
         <div class="ta-wrap"><textarea id="panelBody" placeholder="Nội dung bình luận..."></textarea>
           <button id="panelSend" class="plane-btn" title="Gửi">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 2L11 13"/><path d="M22 2l-7 20-4-9-9-4 20-7z"/></svg>
@@ -158,8 +159,11 @@
         </div>
       </div>
       <div class="mini-composer" id="miniComposer" style="display:none">
-        <input id="miniInput" placeholder="Bình luận nhanh…">
-        <button class="btn plane" id="miniSend" title="Gửi">✈</button>
+        <input id="miniName" placeholder="Tên của bạn...">
+        <div style="display:flex;gap:8px;align-items:center">
+          <input id="miniInput" placeholder="Bình luận nhanh…">
+          <button class="btn plane" id="miniSend" title="Gửi">✈</button>
+        </div>
       </div>
     </div>
   </aside>
@@ -227,6 +231,7 @@
             <div style="font-weight:600">Viết bình luận (GitHub hoặc Ẩn danh)</div>
             <button class="btn small" id="aggAuthBtn">Đăng nhập GitHub</button>
           </div>
+          <input id="chapName" placeholder="Tên của bạn..." style="margin-bottom:8px">
           <div class="ta-wrap"><textarea id="chapBody" placeholder="Nội dung bình luận cho cả chap..."></textarea>
             <button id="chapSend" class="plane-btn" title="Gửi">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 2L11 13"/><path d="M22 2l-7 20-4-9-9-4 20-7z"/></svg>
@@ -293,14 +298,17 @@ async function initDB(){
 }
 
 async function auth_refreshUI(){
-  if(demoMode){ document.getElementById('authName').textContent = anonLabel(); ['authBtn','panelAuthBtn','aggAuthBtn'].forEach(id=>{ const b=document.getElementById(id); if(b) b.textContent='Đăng nhập GitHub';}); return; }
-  const { data: { session } } = await sb.auth.getSession();
-  const { data: { user } } = await sb.auth.getUser();
-  currentUser = session?.user || user || null;
+  if(!demoMode){
+    const { data: { session } } = await sb.auth.getSession();
+    const { data: { user } } = await sb.auth.getUser();
+    currentUser = session?.user || user || null;
+  }
   const name = currentUser ? (currentUser.user_metadata?.user_name || currentUser.user_metadata?.full_name || currentUser.email || 'GitHub') : anonLabel();
   document.getElementById('authName').textContent = name;
   const txt = currentUser ? 'Đăng xuất' : 'Đăng nhập GitHub';
   ['authBtn','panelAuthBtn','aggAuthBtn'].forEach(id=>{ const b=document.getElementById(id); if(b) b.textContent=txt; });
+  ['panelName','chapName','miniName'].forEach(id=>{ const inp=document.getElementById(id); if(inp){ if(currentUser){ inp.value=name; inp.disabled=true; } else { inp.value=''; inp.disabled=false; } }});
+  document.querySelectorAll('.reply-name').forEach(inp=>{ if(currentUser){ inp.value=name; inp.disabled=true; } else { inp.value=''; inp.disabled=false; }});
 }
 async function auth_toggle(){
   if(demoMode) return;
@@ -586,26 +594,29 @@ function bindCommentActions(container){
         await renderAggregated(currentChapter);
       };
     }
-    if(replyBtn){
-      replyBtn.onclick = ()=>{
-        if(wrap.querySelector('.reply-box')){ wrap.querySelector('.reply-box').remove(); return; }
-        const box=document.createElement('div'); box.className='reply-box';
-        box.innerHTML = `<input placeholder="Phản hồi..."/><button class="btn small">Gửi</button>`;
-        wrap.appendChild(box);
-        const inp=box.querySelector('input'); const b=box.querySelector('button');
-        b.onclick = async ()=>{
-          const txt = inp.value.trim(); if(!txt) return;
-          const name = currentUser ? (currentUser.user_metadata?.user_name || currentUser.user_metadata?.full_name || currentUser.email || "GitHub") : anonLabel();
-          const token=uuid();
-          const parent = commentsCache.find(c=>c.id===wrap.dataset.id);
-          const row = await cmt_add({ chapter: currentChapter.index, page: parent.page, name, body: txt, parent_id: wrap.dataset.id, edit_token: token });
-          localStorage.setItem('cmt_token_'+row.id, token);
-          commentsCache.unshift(row);
-          await openMini(currentPageForPanel);
-          await renderAggregated(currentChapter);
+      if(replyBtn){
+        replyBtn.onclick = ()=>{
+          if(wrap.querySelector('.reply-box')){ wrap.querySelector('.reply-box').remove(); return; }
+          const box=document.createElement('div'); box.className='reply-box'; box.style.flexDirection='column';
+          box.innerHTML = `<input class="reply-name" placeholder="Tên của bạn..."/><div style="display:flex;gap:8px;align-items:center"><input class="reply-input" placeholder="Phản hồi..."/><button class="btn small">Gửi</button></div>`;
+          wrap.appendChild(box);
+          const nameInp=box.querySelector('.reply-name');
+          const inp=box.querySelector('.reply-input');
+          const b=box.querySelector('button');
+          if(currentUser){ nameInp.value = currentUser.user_metadata?.user_name || currentUser.user_metadata?.full_name || currentUser.email || 'GitHub'; nameInp.disabled=true; }
+          b.onclick = async ()=>{
+            const txt = inp.value.trim(); if(!txt) return;
+            const name = currentUser ? (currentUser.user_metadata?.user_name || currentUser.user_metadata?.full_name || currentUser.email || "GitHub") : (nameInp.value.trim() || anonLabel());
+            const token=uuid();
+            const parent = commentsCache.find(c=>c.id===wrap.dataset.id);
+            const row = await cmt_add({ chapter: currentChapter.index, page: parent.page, name, body: txt, parent_id: wrap.dataset.id, edit_token: token });
+            localStorage.setItem('cmt_token_'+row.id, token);
+            commentsCache.unshift(row);
+            await openMini(currentPageForPanel);
+            await renderAggregated(currentChapter);
+          };
         };
-      };
-    }
+      }
     // load replies
     renderReplies(wrap.querySelector('[data-replies]'), wrap.dataset.id, commentsCache);
   });
@@ -621,6 +632,11 @@ async function openMini(pageIndex){
   currentPageForPanel = pageIndex;
   document.getElementById('panelTitle').textContent = `Bình luận — #${pageIndex}`;
   document.getElementById('panelBody').value = ''; document.getElementById('panelMsg').textContent='';
+  const nameInp=document.getElementById('panelName');
+  if(nameInp){
+    if(currentUser){ nameInp.value = currentUser.user_metadata?.user_name || currentUser.user_metadata?.full_name || currentUser.email || 'GitHub'; nameInp.disabled=true; }
+    else{ nameInp.disabled=false; }
+  }
 
   const list = commentsCache.filter(c=> c.page === pageIndex);
   renderListInto(document.getElementById('panelList'), list);
@@ -646,7 +662,7 @@ document.getElementById('panelSend').addEventListener('click', async ()=>{
   const msg  = document.getElementById('panelMsg');
   if(!body){ msg.textContent='Viết gì đó đã nha'; return; }
   const cd = checkCooldown('cd_page'); if(cd){ msg.textContent='Chờ '+cd+'s nha'; return; }
-  const name = currentUser ? (currentUser.user_metadata?.user_name || currentUser.user_metadata?.full_name || currentUser.email || "GitHub") : anonLabel();
+  const name = currentUser ? (currentUser.user_metadata?.user_name || currentUser.user_metadata?.full_name || currentUser.email || "GitHub") : (document.getElementById('panelName').value.trim() || anonLabel());
   const token=uuid();
   try{
     const row = await cmt_add({ chapter: currentChapter.index, page: currentPageForPanel, name, body, parent_id: null, edit_token: token });
@@ -668,7 +684,7 @@ document.getElementById('chapSend').addEventListener('click', async ()=>{
   const msg  = document.getElementById('chapMsg');
   if(!body){ msg.textContent='Viết gì đó đã nha'; return; }
   const cd = checkCooldown('cd_chap'); if(cd){ msg.textContent='Chờ '+cd+'s nha'; return; }
-  const name = currentUser ? (currentUser.user_metadata?.user_name || currentUser.user_metadata?.full_name || currentUser.email || "GitHub") : anonLabel();
+  const name = currentUser ? (currentUser.user_metadata?.user_name || currentUser.user_metadata?.full_name || currentUser.email || "GitHub") : (document.getElementById('chapName').value.trim() || anonLabel());
   const token=uuid();
   try{
     const row = await cmt_add({ chapter: currentChapter.index, page: null, name, body, parent_id: null, edit_token: token });


### PR DESCRIPTION
## Summary
- ensure GitHub auth button reflects logged-in state
- add name fields for comments and use anon label when empty

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b8910a82c832287ddc8677ef40c5c