### PR TITLE
Fix icon spacing and comment retrieval

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     .bar{display:flex;gap:12px;align-items:center;flex-wrap:wrap;padding:10px 16px}
     .brand{display:flex;align-items:center;gap:2px;font-weight:800}
     .brand svg{height:46px;width:auto;display:block}
+    .brand svg+svg{margin-left:4px}
     .brand span{font-weight:800;margin-left:8px}
     .pill{display:inline-flex;align-items:center;gap:8px;padding:8px 10px;border:1px solid var(--bd);background:var(--card);border-radius:999px}
     select,button,input,textarea{color:var(--fg);background:var(--card);border:1px solid var(--bd);border-radius:10px;padding:8px 10px}
@@ -396,11 +397,16 @@ async function cmt_fetch(chapter){
     return store.filter(x=>x.chapter===chapter).sort((a,b)=> new Date(b.created_at)-new Date(a.created_at));
   }
   try{
-    const { data, error } = await sb.from('comments').select('*').eq('chapter', chapter).order('created_at', {ascending:false});
+    const { data, error } = await sb.rpc('comment_list', { p_chapter: chapter });
     if(error) throw error; return data||[];
-  }catch(e){
-    enableDemoMode();
-    return await cmt_fetch(chapter);
+  }catch(e1){
+    try{
+      const { data, error } = await sb.from('comments').select('*').eq('chapter', chapter).order('created_at', {ascending:false});
+      if(error) throw error; return data||[];
+    }catch(e2){
+      enableDemoMode();
+      return await cmt_fetch(chapter);
+    }
   }
 }
 // hearts


### PR DESCRIPTION
## Summary
- ensure Cún and cáo header icons have consistent spacing
- fetch comments via Supabase RPC with fallback to load all IDs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b8e2129308322b9b1a7a995c4a62f