### PR TITLE
Fix async function declaration for mini panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -675,8 +675,7 @@ function renderListInto(el, items){
 
 
 
-async 
-function openMini(pageIndex){
+async function openMini(pageIndex){
   // Mở mini panel và load Giscus theo từng ảnh
   const panel = document.getElementById('miniPanel');
   // Hiện overlay (nếu có trong layout của m)


### PR DESCRIPTION
## Summary
- Fix stray async keyword by properly declaring `openMini` as an async function

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_689c8f22e2b883229c91af9bda11c53e