### PR TITLE
fix: handle auth callback

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,22 @@ function enable(el, on){ el.disabled = !on; }
 
 // auth
 async function ensureAuth(){
+  // After redirect back from an OAuth provider the auth code is appended to the URL.
+  // Exchange it for a session so that `getSession` returns the logged in user.
+  try{
+    const url = new URL(location.href);
+    if(url.searchParams.get('code') || url.hash.includes('access_token')){
+      const { error } = await sb.auth.exchangeCodeForSession(url.href);
+      if(error){
+        console.error('exchangeCodeForSession', error);
+      }else{
+        // clean auth params from url for a nicer experience
+        history.replaceState({}, document.title, url.origin + url.pathname + url.hash.split('&')[0]);
+      }
+    }
+  }catch(err){
+    console.error('ensureAuth', err);
+  }
   const { data:{ session } } = await sb.auth.getSession();
   user = session?.user || null;
   onAuthUI();


### PR DESCRIPTION
## Summary
- handle Supabase OAuth callback by exchanging code for session
- clean auth params from URL after login

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dabf282e883229851cc9afe1a1c7a